### PR TITLE
Add FinRL-based Binance trading bot scaffold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# --- Binance ---
+BINANCE_API_KEY=
+BINANCE_API_SECRET=
+# "LIVE" hoặc "PAPER"
+TRADING_MODE=PAPER
+
+# Cặp giao dịch & khung thời gian
+SYMBOL=BTCUSDT
+INTERVAL=1m
+
+# Kích thước vị thế & kiểm soát rủi ro
+POSITION_PCT=0.2
+MAX_DAILY_LOSS_PCT=5
+STOP_LOSS_PCT=0.5
+TAKE_PROFIT_PCT=1.0
+COOLDOWN_SEC=30
+
+# Đường dẫn model RL (SB3: PPO/SAC/…)
+RL_MODEL_PATH=models/ppo_btcusdt.zip
+
+# Sổ nhật ký
+LOG_DIR=logs

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Auto Crypto Trading Bot (FinRL + Binance)
+
+## 1. Cài đặt
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+pip install -r requirements.txt
+cp .env.example .env
+```
+
+## 2. Chuẩn bị model RL (SB3)
+
+* Bạn có thể train trước với FinRL/Stable-Baselines3 (PPO) để tạo file `models/ppo_btcusdt.zip`.
+* Hoặc tạm **mock** một policy đơn giản rồi thay bằng RL sau.
+
+## 3. Chạy bot (paper)
+
+```bash
+python bot.py
+```
+
+Mặc định `TRADING_MODE=PAPER` → bot **không** gửi lệnh thật, chỉ journal.
+
+## 4. Bật live trading (rất cẩn thận)
+
+* Chuyển `TRADING_MODE=LIVE` trong `.env`
+* Đảm bảo API Key có quyền **Spot trading** và bật IP whitelist.
+* Bắt buộc chạy nhỏ / giới hạn rủi ro, thử Testnet trước.
+
+## 5. Lưu ý an toàn
+
+* Giới hạn `POSITION_PCT`, `MAX_DAILY_LOSS_PCT`.
+* Thử trên `INTERVAL=1m/5m` với số vốn nhỏ.
+* Luôn có cơ chế dừng khẩn cấp (kill switch).

--- a/api/server.py
+++ b/api/server.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class PauseReq(BaseModel):
+    campaign: str
+    seconds: int = 900
+
+
+@app.get("/health")
+async def health():
+    return {"ok": True}
+
+
+@app.post("/pause")
+async def pause(req: PauseReq):
+    return {"status": "paused", "campaign": req.campaign, "seconds": req.seconds}

--- a/backtest.py
+++ b/backtest.py
@@ -1,0 +1,5 @@
+"""Placeholder for a backtesting implementation.
+
+Add logic here to replay historical candles through the same
+observation/action flow used in ``bot.py``.
+"""

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,96 @@
+import time
+from typing import Tuple
+
+import numpy as np
+from binance.spot import Spot
+
+from config import (
+    COOLDOWN_SEC,
+    INTERVAL,
+    MAX_DAILY_LOSS_PCT,
+    POSITION_PCT,
+    RL_MODEL_PATH,
+    SYMBOL,
+)
+from data_stream import CandleFeed
+from executor import Executor
+from risk import RiskState, position_size
+from strategy_rl import RLPolicy
+
+
+DEFAULT_STARTING_USDT = 10000.0
+
+
+def build_observation(df, equity_usdt: float, pos_base_qty: float, price: float) -> np.ndarray:
+    close = df["close"]
+    ret_1 = (close.iloc[-1] / close.iloc[-2] - 1.0) if len(close) > 1 else 0.0
+    ret_5 = (close.iloc[-1] / close.iloc[-6] - 1.0) if len(close) > 6 else 0.0
+    vol_20 = close.pct_change().rolling(20).std().iloc[-1] if len(close) > 20 else 0.0
+    pos_value = pos_base_qty * price
+    pos_pct = pos_value / max(equity_usdt, 1e-6)
+    cash_pct = max(0.0, 1.0 - pos_pct)
+    obs = np.array([ret_1, ret_5, vol_20, pos_pct, cash_pct], dtype=np.float32)
+    return obs
+
+
+def fetch_initial_balances(client: Spot) -> Tuple[float, float]:  # pragma: no cover - network path
+    try:
+        account = client.account()
+        usdt = next((float(b["free"]) for b in account["balances"] if b["asset"] == "USDT"), DEFAULT_STARTING_USDT)
+        base = next((float(b["free"]) for b in account["balances"] if b["asset"] == SYMBOL[:-4]), 0.0)
+        return usdt, base
+    except Exception:
+        return DEFAULT_STARTING_USDT, 0.0
+
+
+def main() -> None:  # pragma: no cover - runtime loop
+    print("Starting Auto Trading Bot (PAPER by default)…")
+    feed = CandleFeed(SYMBOL, INTERVAL, limit=200)
+    executor = Executor(SYMBOL)
+
+    client = Spot()
+    usdt_free, base_free = fetch_initial_balances(client)
+    price = feed.latest_close()
+    executor.on_account(usdt_free=usdt_free, base_free=base_free, price=price)
+
+    risk = RiskState(
+        start_equity=executor.equity_usdt or DEFAULT_STARTING_USDT,
+        max_daily_loss_pct=MAX_DAILY_LOSS_PCT,
+        cooldown_sec=COOLDOWN_SEC,
+    )
+    policy = RLPolicy("ppo", RL_MODEL_PATH)
+
+    while True:
+        df = feed.fetch()
+        price = float(df["close"].iloc[-1])
+        base_qty = executor.pos.base_qty
+        equity = usdt_free + base_qty * price
+        executor.on_account(usdt_free=usdt_free, base_free=base_qty, price=price)
+
+        now = time.time()
+        if not risk.allow_trade(now_ts=now, cur_equity=equity):
+            executor.check_sl_tp(price)
+            time.sleep(3)
+            continue
+
+        obs = build_observation(df, equity, base_qty, price)
+        action = policy.predict_action(obs)
+
+        if action == 2:
+            quote_amt = position_size(equity, POSITION_PCT)
+            if quote_amt > 10:
+                executor.buy(quote_amt, price)
+                usdt_free -= quote_amt
+                risk.mark_trade(now)
+        elif action == 0 and base_qty > 0.0:
+            executor.sell(base_qty, price)
+            usdt_free += base_qty * price
+            base_qty = 0.0
+            risk.mark_trade(now)
+
+        executor.check_sl_tp(price)
+        time.sleep(5)
+
+
+if __name__ == "__main__":
+    main()

--- a/config.py
+++ b/config.py
@@ -1,0 +1,22 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+BINANCE_API_KEY = os.getenv("BINANCE_API_KEY", "")
+BINANCE_API_SECRET = os.getenv("BINANCE_API_SECRET", "")
+TRADING_MODE = os.getenv("TRADING_MODE", "PAPER").upper()
+
+SYMBOL = os.getenv("SYMBOL", "BTCUSDT")
+INTERVAL = os.getenv("INTERVAL", "1m")
+
+POSITION_PCT = float(os.getenv("POSITION_PCT", 0.2))
+MAX_DAILY_LOSS_PCT = float(os.getenv("MAX_DAILY_LOSS_PCT", 5))
+STOP_LOSS_PCT = float(os.getenv("STOP_LOSS_PCT", 0.5))
+TAKE_PROFIT_PCT = float(os.getenv("TAKE_PROFIT_PCT", 1.0))
+COOLDOWN_SEC = int(os.getenv("COOLDOWN_SEC", 30))
+
+RL_MODEL_PATH = os.getenv("RL_MODEL_PATH", "models/ppo_btcusdt.zip")
+
+LOG_DIR = os.getenv("LOG_DIR", "logs")
+os.makedirs(LOG_DIR, exist_ok=True)

--- a/data_stream.py
+++ b/data_stream.py
@@ -1,0 +1,39 @@
+from typing import Optional
+
+import pandas as pd
+from binance.spot import Spot
+
+
+class CandleFeed:
+    def __init__(self, symbol: str, interval: str = "1m", limit: int = 200, client: Optional[Spot] = None):
+        self.symbol = symbol
+        self.interval = interval
+        self.limit = limit
+        self.client = client or Spot()
+
+    def fetch(self) -> pd.DataFrame:
+        raw = self.client.klines(self.symbol, self.interval, limit=self.limit)
+        cols = [
+            "open_time",
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+            "close_time",
+            "qav",
+            "trades",
+            "tb_base",
+            "tb_quote",
+            "ignore",
+        ]
+        df = pd.DataFrame(raw, columns=cols)
+        for col in ["open", "high", "low", "close", "volume", "qav", "tb_base", "tb_quote"]:
+            df[col] = df[col].astype(float)
+        df["open_time"] = pd.to_datetime(df["open_time"], unit="ms", utc=True)
+        df["close_time"] = pd.to_datetime(df["close_time"], unit="ms", utc=True)
+        return df
+
+    def latest_close(self) -> float:
+        df = self.fetch()
+        return float(df["close"].iloc[-1])

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENV PYTHONUNBUFFERED=1
+CMD ["python", "bot.py"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+services:
+  bot:
+    build: ..
+    env_file: ../.env
+    restart: always
+    volumes:
+      - ..:/app
+    command: ["python", "bot.py"]
+  api:
+    build: ..
+    env_file: ../.env
+    restart: unless-stopped
+    command: ["uvicorn", "api.server:app", "--host", "0.0.0.0", "--port", "8000"]
+    ports: ["8000:8000"]

--- a/exchange.py
+++ b/exchange.py
@@ -1,0 +1,62 @@
+import logging
+from typing import Any, Dict, Optional
+
+from binance.spot import Spot
+
+from config import BINANCE_API_KEY, BINANCE_API_SECRET
+
+logger = logging.getLogger(__name__)
+
+
+class BinanceSpot:
+    """Thin wrapper around the Binance Spot REST client."""
+
+    def __init__(self, symbol: str, client: Optional[Spot] = None):
+        self.symbol = symbol
+        self.client = client or Spot(api_key=BINANCE_API_KEY, api_secret=BINANCE_API_SECRET)
+        self.filters = self._load_symbol_filters()
+
+    def _load_symbol_filters(self) -> Dict[str, Any]:
+        try:
+            info = self.client.exchange_info(symbol=self.symbol)
+            sym = info["symbols"][0]
+            filters = {f["filterType"]: f for f in sym["filters"]}
+            return filters
+        except Exception as exc:  # pragma: no cover - network path
+            logger.warning("Failed to load symbol filters for %s: %s", self.symbol, exc)
+            return {}
+
+    def _round_step(self, qty: float) -> float:
+        if not self.filters:
+            return float(f"{qty:.8f}")
+        step = float(self.filters["LOT_SIZE"]["stepSize"])
+        precision = max(0, str(step)[::-1].find("."))
+        return float(f"{qty:.{precision}f}")
+
+    def _round_tick(self, price: float) -> float:
+        if not self.filters:
+            return float(f"{price:.8f}")
+        tick = float(self.filters["PRICE_FILTER"]["tickSize"])
+        precision = max(0, str(tick)[::-1].find("."))
+        return float(f"{price:.{precision}f}")
+
+    def get_price(self) -> float:
+        ticker = self.client.ticker_price(self.symbol)
+        return float(ticker["price"])
+
+    def get_balance(self, asset: str) -> float:
+        account = self.client.account()
+        for balance in account.get("balances", []):
+            if balance["asset"] == asset:
+                return float(balance["free"])
+        return 0.0
+
+    def market_buy(self, quote_amount: float) -> Dict[str, Any]:
+        price = self.get_price()
+        qty = quote_amount / price
+        qty = self._round_step(qty)
+        return self.client.new_order(symbol=self.symbol, side="BUY", type="MARKET", quantity=qty)
+
+    def market_sell(self, base_qty: float) -> Dict[str, Any]:
+        qty = self._round_step(base_qty)
+        return self.client.new_order(symbol=self.symbol, side="SELL", type="MARKET", quantity=qty)

--- a/executor.py
+++ b/executor.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from config import STOP_LOSS_PCT, TAKE_PROFIT_PCT, TRADING_MODE
+from exchange import BinanceSpot
+
+
+@dataclass
+class Position:
+    base_qty: float = 0.0
+    avg_price: float = 0.0
+
+
+class Executor:
+    def __init__(self, symbol: str):
+        self.symbol = symbol
+        self.mode = TRADING_MODE
+        self.ex = BinanceSpot(symbol)
+        self.pos = Position()
+        self.equity_usdt: Optional[float] = None
+
+    def on_account(self, usdt_free: float, base_free: float, price: float) -> None:
+        self.equity_usdt = usdt_free + base_free * price
+        if self.pos.base_qty == 0:
+            self.pos.avg_price = 0.0
+
+    def _paper_buy(self, quote_amount: float, price: float) -> None:
+        qty = quote_amount / price
+        if self.pos.base_qty > 0:
+            self.pos.avg_price = (
+                self.pos.avg_price * self.pos.base_qty + price * qty
+            ) / (self.pos.base_qty + qty)
+        else:
+            self.pos.avg_price = price
+        self.pos.base_qty += qty
+        print(f"[PAPER] BUY {qty:.6f} @ {price}")
+
+    def _paper_sell(self, qty: float, price: float) -> None:
+        qty = min(qty, self.pos.base_qty)
+        self.pos.base_qty -= qty
+        print(f"[PAPER] SELL {qty:.6f} @ {price}")
+        if self.pos.base_qty == 0:
+            self.pos.avg_price = 0.0
+
+    def buy(self, quote_amount: float, price: Optional[float] = None) -> None:
+        px = price or self.ex.get_price()
+        if self.mode == "PAPER":
+            self._paper_buy(quote_amount, px)
+        else:
+            resp = self.ex.market_buy(quote_amount)
+            print("[LIVE] BUY resp:", resp)
+
+    def sell(self, qty: float, price: Optional[float] = None) -> None:
+        px = price or self.ex.get_price()
+        if self.mode == "PAPER":
+            self._paper_sell(qty, px)
+        else:
+            resp = self.ex.market_sell(qty)
+            print("[LIVE] SELL resp:", resp)
+
+    def check_sl_tp(self, price: float) -> None:
+        if self.pos.base_qty <= 0 or self.pos.avg_price <= 0:
+            return
+        sl = self.pos.avg_price * (1 - STOP_LOSS_PCT / 100)
+        tp = self.pos.avg_price * (1 + TAKE_PROFIT_PCT / 100)
+        if price <= sl:
+            print("[RISK] Stop-loss triggered")
+            self.sell(self.pos.base_qty, price)
+        elif price >= tp:
+            print("[RISK] Take-profit triggered")
+            self.sell(self.pos.base_qty, price)

--- a/main.py
+++ b/main.py
@@ -1,1 +1,4 @@
+"""Entry point placeholder."""
 
+if __name__ == "__main__":
+    print("Refer to bot.py for the trading loop.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+python-dotenv==1.0.1
+pandas==2.2.2
+numpy==1.26.4
+binance-connector==3.6.0
+websocket-client==1.8.0
+requests==2.32.3
+pytz==2024.1
+stable-baselines3==2.3.2
+torch>=2.2.0
+fastapi==0.111.0
+uvicorn==0.30.1
+FinRL==0.3.6
+pydantic==2.7.2

--- a/risk.py
+++ b/risk.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class RiskState:
+    start_equity: float
+    max_daily_loss_pct: float
+    cooldown_sec: int
+    last_trade_ts: Optional[float] = None
+
+    def allow_trade(self, now_ts: float, cur_equity: float) -> bool:
+        drawdown = 100.0 * (1.0 - cur_equity / max(self.start_equity, 1e-6))
+        if drawdown > self.max_daily_loss_pct:
+            return False
+        if self.last_trade_ts is not None and (now_ts - self.last_trade_ts) < self.cooldown_sec:
+            return False
+        return True
+
+    def mark_trade(self, now_ts: float) -> None:
+        self.last_trade_ts = now_ts
+
+
+def position_size(equity_usdt: float, pct: float) -> float:
+    return max(0.0, equity_usdt * pct)

--- a/screener.py
+++ b/screener.py
@@ -1,0 +1,49 @@
+"""Simple placeholder screener module.
+
+The original project references a richer implementation that
+ranks symbols by a blended risk/reward score.  For now we expose a
+minimal CLI helper that can be extended with additional metrics.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import List
+
+
+DEFAULT_SYMBOLS = [
+    "BTCUSDT",
+    "ETHUSDT",
+    "BNBUSDT",
+    "SOLUSDT",
+    "XRPUSDT",
+    "ADAUSDT",
+    "DOGEUSDT",
+    "AVAXUSDT",
+    "LINKUSDT",
+    "DOTUSDT",
+    "MATICUSDT",
+    "TRXUSDT",
+    "UNIUSDT",
+    "LTCUSDT",
+    "ATOMUSDT",
+]
+
+
+def run(limit: int) -> List[str]:
+    symbols = DEFAULT_SYMBOLS[:limit]
+    print("Top symbols (static placeholder):")
+    for idx, sym in enumerate(symbols, start=1):
+        print(f"{idx:>2}: {sym}")
+    return symbols
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Print placeholder screener results")
+    parser.add_argument("--limit", type=int, default=15, help="Number of symbols to show")
+    args = parser.parse_args()
+    run(args.limit)
+
+
+if __name__ == "__main__":
+    main()

--- a/strategy_rl.py
+++ b/strategy_rl.py
@@ -1,0 +1,31 @@
+from typing import Literal
+
+import numpy as np
+from stable_baselines3 import A2C, DDPG, PPO, SAC, TD3
+
+RLAlgo = Literal["ppo", "sac", "a2c", "td3", "ddpg"]
+
+
+class RLPolicy:
+    def __init__(self, algo: RLAlgo, model_path: str):
+        self.algo = algo.lower()
+        if self.algo == "ppo":
+            self.model = PPO.load(model_path)
+        elif self.algo == "sac":
+            self.model = SAC.load(model_path)
+        elif self.algo == "a2c":
+            self.model = A2C.load(model_path)
+        elif self.algo == "td3":
+            self.model = TD3.load(model_path)
+        elif self.algo == "ddpg":
+            self.model = DDPG.load(model_path)
+        else:
+            raise ValueError("Unsupported algo")
+
+    def predict_action(self, obs: np.ndarray) -> int:
+        action, _ = self.model.predict(obs, deterministic=True)
+        if isinstance(action, np.ndarray):
+            mapped = int(np.clip(round(float(action[0]) * 1.5 + 1), 0, 2))
+        else:
+            mapped = int(action)
+        return mapped

--- a/training/finrl_config.yaml
+++ b/training/finrl_config.yaml
@@ -1,0 +1,15 @@
+spot:
+  algo: ppo
+  interval: 1h
+  start: 2022-01-01
+  end: 2025-09-30
+  timesteps: 1500000
+  symbols: [BTCUSDT, ETHUSDT]
+
+futures:
+  algo: sac
+  interval: 1h
+  start: 2022-01-01
+  end: 2025-09-30
+  timesteps: 1500000
+  symbols: [BTCUSDT, ETHUSDT]

--- a/training/train_finrl.py
+++ b/training/train_finrl.py
@@ -1,0 +1,77 @@
+import argparse
+import os
+from datetime import datetime
+
+import pandas as pd
+
+from finrl.agents.stablebaselines3_models import DRLAgent
+from finrl.env.env_stocktrading import StockTradingEnv
+from finrl.marketdata.binance import BinanceProcessor
+
+ALGOS = {
+    "ppo": "ppo",
+    "sac": "sac",
+}
+
+
+def fetch_binance(symbol: str, interval: str, start: str, end: str) -> pd.DataFrame:
+    dp = BinanceProcessor()
+    df = dp.fetch_data(symbol=symbol, interval=interval, start_date=start, end_date=end)
+    df = df.rename(
+        columns={
+            "open_time": "date",
+            "close": "close",
+            "open": "open",
+            "high": "high",
+            "low": "low",
+            "volume": "volume",
+        }
+    )
+    df["date"] = pd.to_datetime(df["date"])
+    df["tic"] = symbol
+    return df[["date", "tic", "open", "high", "low", "close", "volume"]]
+
+
+def build_env(df: pd.DataFrame, initial_amount: float = 10000, turbulence_threshold: int = 1_000_000):
+    env = StockTradingEnv(
+        df=df,
+        initial_amount=initial_amount,
+        turbulence_threshold=turbulence_threshold,
+        risk_indicator_col="close",
+        hmax=1_000_000,
+        reward_scaling=1.0,
+    )
+    return env
+
+
+def train(mode: str, symbols: list, interval: str, start: str, end: str, timesteps: int, save_dir: str):
+    os.makedirs(save_dir, exist_ok=True)
+    frames = [fetch_binance(sym, interval, start, end) for sym in symbols]
+    df = pd.concat(frames).sort_values(["date", "tic"]).reset_index(drop=True)
+
+    env = build_env(df)
+    agent = DRLAgent(env=env)
+
+    algo = "ppo" if mode == "spot" else "sac"
+    model = agent.get_model(ALGOS[algo])
+
+    trained = agent.train_model(model=model, tb_log_name=f"{algo}_{mode}", total_timesteps=timesteps)
+
+    stamp = datetime.utcnow().strftime("%Y%m%d_%H%M")
+    filename = f"{algo}_{mode}_{'_'.join(symbols)}_{stamp}.zip"
+    out_path = os.path.join(save_dir, filename)
+    trained.save(out_path)
+    print("Saved:", out_path)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=["spot", "futures"], required=True)
+    parser.add_argument("--symbols", nargs="+", required=True)
+    parser.add_argument("--interval", default="1h")
+    parser.add_argument("--start", required=True)
+    parser.add_argument("--end", required=True)
+    parser.add_argument("--timesteps", type=int, default=1_000_000)
+    parser.add_argument("--save_dir", default="models")
+    args = parser.parse_args()
+    train(args.mode, args.symbols, args.interval, args.start, args.end, args.timesteps, args.save_dir)


### PR DESCRIPTION
## Summary
- add configuration, environment template, and project dependencies for the crypto trading bot
- implement Binance exchange wrapper, risk controls, RL strategy loader, data feed, and paper/live executor
- provide trading loop, training scripts, Docker setup, API stub, and project documentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e21fa165c8832084d7a2f5ce5b66b4